### PR TITLE
Add CODEOWNERS and CONTRIBUTING.md file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. A merge to the master branch will require one approval
+# from the following:
+*       @0xalexdelgado @0xCollinMontenegro

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to `shad0w-pr0jects`
+
+Hello! We are excited that you would like to contribute and we welcome any additions and/or edits.
+This document outlines what you should do if you'd like to add yourself to the list or make any edits.
+Please read this in it's entirety before submitting a pull request.
+
+### Contributing
+
+Prerequisites: 
+* A GitHub account
+* Git
+
+1. Fork this repository
+2. Clone the forked repository to your local computer
+3. Go to the repository on your computer and create a feature branch (`git checkout -b adding-my-awesome-project`)
+4. Make your changes, save them, and commit them (`git commit -m "Added ghosty to the list"`)
+5. Publish the branch (`git push origin <branch-name>`)
+6. Create a Pull Request on GitHub
+
+### Formatting
+
+Add your GitHub name with a link to your profile as a fourth level heading and the projects underneath it. 
+Example:
+
+```
+#### [@droberson](https://github.com/droberson)
+
+[ssh-honeypot](https://github.com/droberson/ssh-honeypot)
+
+[rtfm](https://github.com/droberson/rtfm)
+``` 


### PR DESCRIPTION
**Summary**
CONTRIBUTING.md - Adds some guidelines to contributing. Can always be improved and added to but wanted to get something up there. 

CODEOWNERS - Adds us as the codeowners for all branches of the repo. Once this is merged I'll set a rule that will require any merges to master to have at least one approval from someone in the codeowners file. This is how GitHub does default reviewers. 